### PR TITLE
copy binary and fix file names

### DIFF
--- a/packer/playbooks/apps.yml
+++ b/packer/playbooks/apps.yml
@@ -53,16 +53,16 @@
   become: true
 
 - name: Move 'launch.sh' File to '/src/clumsy-bird' Directory
-  command: mv /tmp/assets/launch.sh /src/clumsy-bird/launch.sh
+  command: mv /tmp/assets/setup-web.sh /src/clumsy-bird/launch.sh
   become: true
-    
+
 - name: Change Value of Clumsy Bird Permissions
   file:
     path: /src/clumsy-bird/launch.sh
     mode: a+x
   become: true
 
-- name: Change Ownership of '/src/clumsy-bird' 
+- name: Change Ownership of '/src/clumsy-bird'
   file:
     path: /src/clumsy-bird/
     recurse: yes
@@ -71,7 +71,11 @@
   become: true
 
 - name: Add Clumsy Bird to path
-  command: cp /tmp/assets/clumsy-bird.service /lib/systemd/system/clumsy-bird.service
+  command: cp /tmp/assets/webapp.service /lib/systemd/system/clumsy-bird.service
+  become: true
+
+- name: Add Clumsy Bird bin
+  command: cp /tmp/assets/webapp /usr/local/bin/webapp
   become: true
 
 - name: Start and Enable Clumsy Bird Service


### PR DESCRIPTION
binary was not copied to device. file names were off

```
    azure-arm.clumsybird: PLAY RECAP *********************************************************************
    azure-arm.clumsybird: default                    : ok=39   changed=22   unreachable=0    failed=0    skipped=9    rescued=0    ignored=0
```

app now runs:

```
$ sudo systemctl status clumsy-bird
● clumsy-bird.service - Demo web app
     Loaded: loaded (/lib/systemd/system/clumsy-bird.service; enabled; vendor preset: enabled)
     Active: active (running) since Tue 2023-04-18 15:49:10 UTC; 1min 40s ago
   Main PID: 699 (webapp)
      Tasks: 4 (limit: 9531)
     Memory: 7.8M
     CGroup: /system.slice/clumsy-bird.service
             └─699 /usr/local/bin/webapp >> /var/log/webapp.lo
```