### PR TITLE
fix unquoted string in eip domain property

### DIFF
--- a/terraform/Hands-On Labs/Section 02 - Understand IAC Concepts/02 - Benefits_of_Infrastructure_as_Code.md
+++ b/terraform/Hands-On Labs/Section 02 - Understand IAC Concepts/02 - Benefits_of_Infrastructure_as_Code.md
@@ -312,7 +312,7 @@ resource "aws_internet_gateway" "internet_gateway" {
 
 #Create EIP for NAT Gateway
 resource "aws_eip" "nat_gateway_eip" {
-  domain     = vpc
+  domain     = "vpc"
   depends_on = [aws_internet_gateway.internet_gateway]
   tags = {
     Name = "demo_igw_eip"


### PR DESCRIPTION
This corrects an error:

Error: Invalid reference
│ 
│   on main.tf line 102, in resource "aws_eip" "nat_gateway_eip":
│  102:   domain     = vpc
│ 
│ A reference to a resource type must be followed by at least one attribute access, specifying the resource name.
╵