### PR TITLE
fix: Update AWS S3 Bucket creation code example

### DIFF
--- a/terraform/Hands-On Labs/Section 04 - Understand Terraform Basics/05 - Intro_to_the_Terraform_Resource_Block.md
+++ b/terraform/Hands-On Labs/Section 04 - Understand Terraform Basics/05 - Intro_to_the_Terraform_Resource_Block.md
@@ -67,9 +67,18 @@ resource "aws_s3_bucket" "my-new-S3-bucket" {
   } 
 }
 
+resource "aws_s3_bucket_ownership_controls" "my_s3_bucket_ownership_controls" {
+  bucket = aws_s3_bucket.my_new_s3_bucket.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_ownership_controls" "my_new_bucket_acl" {   
+  depends_on = [aws_s3_bucket_ownership_controls.my_s3_bucket_ownership_controls]
+
   bucket = aws_s3_bucket.my-new-S3-bucket.id  
-  rule {     
+  rule {
     object_ownership = "BucketOwnerPreferred"   
   }
 }


### PR DESCRIPTION
The creation of AWS S3 buckets has changed. After trying to, unsuccessfully, create it, I headed to https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl to check the updated way of doing it. Hence why this pull request.

Please, feel free to update anything necessary or let me know if I am missing something or did something wrong!

Have a nice day :)