### PR TITLE
fix: repalce t3.micro EC2 instances with t2.micro EC2 instnaces

### DIFF
--- a/terraform/Lab Prerequisites/Section 05 - Use Terraform outside of core workflow/Terraform Taint and Replace/main.tf
+++ b/terraform/Lab Prerequisites/Section 05 - Use Terraform outside of core workflow/Terraform Taint and Replace/main.tf
@@ -147,7 +147,7 @@ data "aws_ami" "ubuntu" {
 # Terraform Resource Block - To Build EC2 instance in Public Subnet
 resource "aws_instance" "ubuntu_server" {
   ami                         = data.aws_ami.ubuntu.id
-  instance_type               = "t3.micro"
+  instance_type               = "t2.micro"
   subnet_id                   = aws_subnet.public_subnets["public_subnet_1"].id
   security_groups             = [aws_security_group.vpc-ping.id, aws_security_group.ingress-ssh.id, aws_security_group.vpc-web.id]
   associate_public_ip_address = true


### PR DESCRIPTION
this fix replaces t3.micro EC2 instances with t2.micro EC2 instances, as t3.micro is not free in all regions, which can result in unexpected charges for students. 