### PR TITLE
Hands-On Labs/Section 09 - Read Generate and Modify Configuration /01 - Local_Values.md

### DIFF
--- a/terraform/Hands-On Labs/Section 09 - Read Generate and Modify Configuration/01 - Local_Values.md
+++ b/terraform/Hands-On Labs/Section 09 - Read Generate and Modify Configuration/01 - Local_Values.md
@@ -51,7 +51,7 @@ Add another local values block to your `main.tf` module configuration that refer
 locals {
   # Common tags to be assigned to all resources
   common_tags = {
-    Name      = var.server_name
+    Name      = local.server_name
     Owner     = local.team
     App       = local.application
     Service   = local.service_name


### PR DESCRIPTION
Fix line 54 where `local.server_name` is used in hands-On Lab video instead of `var.server_name `