### PR TITLE
Bug Fix: Error: Value for unconfigurable attribute

### DIFF
--- a/terraform/Lab Prerequisites/Section 05 - Use Terraform outside of core workflow/Terraform Taint and Replace/main.tf
+++ b/terraform/Lab Prerequisites/Section 05 - Use Terraform outside of core workflow/Terraform Taint and Replace/main.tf
@@ -105,7 +105,7 @@ resource "aws_internet_gateway" "internet_gateway" {
 
 #Create EIP for NAT Gateway
 resource "aws_eip" "nat_gateway_eip" {
-  domain     = "vpc"
+  vpc        = true
   depends_on = [aws_internet_gateway.internet_gateway]
   tags = {
     Name = "demo_igw_eip"


### PR DESCRIPTION
When running this code as is I get an error:

```
Error: Value for unconfigurable attribute
│ 
│   with aws_eip.nat_gateway_eip,
│   on main.tf line 108, in resource "aws_eip" "nat_gateway_eip":
│  108:   domain     = "vpc"
```

I updated the line to the property which was used in the course video, which was: vpc = true